### PR TITLE
Store JSON for things, collections, and user designs

### DIFF
--- a/thingy_grabber.py
+++ b/thingy_grabber.py
@@ -369,6 +369,8 @@ class Designs(Grouping):
         Grouping.__init__(self, quick, compress, api_key)
         self.user = user
         self.url = API_USER_DESIGNS.format(user, api_key)
+        self.info_url = API_USER_DESIGNS.format(user,api_key)
+        self.info_filename = 'designs:{}.json'.format(user)
         self.download_dir = os.path.join(
             directory, "{} designs".format(slugify(self.user)))
 

--- a/thingy_grabber.py
+++ b/thingy_grabber.py
@@ -20,6 +20,7 @@ import glob
 import shutil
 from io import StringIO
 from html.parser import HTMLParser
+import json
 
 SEVENZIP_FILTERS = [{'id': py7zr.FILTER_LZMA2}]
 
@@ -365,6 +366,7 @@ class Thing:
         self.time_stamp = None
         self._file_links = FileLinks()
         self._image_links = []
+        self._json = None
 
     @classmethod
     def from_thing_id(cls, thing_id):
@@ -398,6 +400,7 @@ class Thing:
             return
 
         thing_json = current_req.json()
+        self._json = thing_json
         try:
             self._license = thing_json['license']
         except KeyError:
@@ -736,6 +739,15 @@ class Thing:
                     readme_handle.write("{}\n".format(self._details))
         except IOError as exception:
             logging.warning("Failed to write readme! {}".format(exception))
+
+        logging.info("writing thing json")
+        try:
+            if self._json:
+                with open(truncate_name(os.path.join(self.download_dir, 'thing:{}.json'.format(self.thing_id))), 'w',
+                          encoding="utf-8") as json_handle:
+                    json.dump(self._json, json_handle, indent=2)
+        except IOError as exception:
+            logging.warning("Failed to write thing json! {}".format(exception))
 
         try:
             # Now write the timestamp


### PR DESCRIPTION
Greetings,

I am looking at offline archiving my collections and designs from thingiverse, juuust in case, given its current state. To this end, I've started adding basic support for dumping the raw JSON details for things, collections, and the list of user designs. My hope is that sometime down the line this can be used by an importer to mediagoblin or something similar, or otherwise post-processed.

For now, it just unconditionally dumps the JSON (and doesn't do any checks for API errors to make sure it's actually returning the requested information), and dumps to "thing:$id.json", "collection:$id.json", or "designs:$username.json" mirroring how thingiverse labels them.

If this looks OK as a first pass, I was going to add some error checking code in the Grouping. If this looks OK generally, do you think it should be controlled with an argument? something like "--dump-json={all,designs,thing,collection}" maybe.